### PR TITLE
feat: emit type_registry() and MCP tools docs for endpoint-libs MCP surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,8 +874,6 @@ dependencies = [
 [[package]]
 name = "endpoint-libs"
 version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d9959940db6a9a2b5669b28f9a19da93be67b7acc5cdabf598aa3a81ae2075"
 dependencies = [
  "alloy-primitives",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
 [[package]]
 name = "endpoint-libs"
 version = "1.8.2"
+source = "git+https://github.com/pathscale/endpoint-libs?branch=main#960ec49a71b1745e5e9fad0d94df07b15ec33043"
 dependencies = [
  "alloy-primitives",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ toml = "0.9"
 # Remove once endpoint-libs with the MCP surface is published and the
 # `endpoint-libs` version requirement above is bumped to match.
 [patch.crates-io]
-endpoint-libs = { git = "https://github.com/pathscale/endpoint-libs", branch = "mcp/pr3-wiring" }
+endpoint-libs = { git = "https://github.com/pathscale/endpoint-libs", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,9 @@ smart-serde-default = "0.1"
 
 [build-dependencies]
 toml = "0.9"
+
+# TEMPORARY: TypeRegistry / MCP schema APIs are not yet released on crates.io.
+# Remove once endpoint-libs with the MCP surface is published and the
+# `endpoint-libs` version requirement above is bumped to match.
+[patch.crates-io]
+endpoint-libs = { path = "../endpoint-libs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ toml = "0.9"
 # Remove once endpoint-libs with the MCP surface is published and the
 # `endpoint-libs` version requirement above is bumped to match.
 [patch.crates-io]
-endpoint-libs = { path = "../endpoint-libs" }
+endpoint-libs = { git = "https://github.com/pathscale/endpoint-libs", branch = "mcp/pr3-wiring" }

--- a/src/definitions.rs
+++ b/src/definitions.rs
@@ -13,7 +13,7 @@ use smart_serde_default::smart_serde_default;
 
 #[derive(Serialize, Deserialize)]
 pub enum Definition {
-    EndpointSchema(EndpointSchemaDefinition),
+    EndpointSchema(Box<EndpointSchemaDefinition>),
     EndpointSchemaList(EndpointSchemaListDefinition),
     Enum(EnumElement),
     EnumList(EnumListDefinition),

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -268,6 +268,57 @@ ID: {}
     Ok(())
 }
 
+/// Writes `docs/<service>_mcp_tools.json` for each service: the MCP tool list
+/// (name, description, inputSchema, outputSchema) exactly as a server built
+/// from these schemas will report it via `tools/list`. Intended for review —
+/// schema changes show up as diffs in these files.
+pub fn gen_mcp_tools_json(data: &Data) -> eyre::Result<()> {
+    let docs_dir = data.project_root.join("docs");
+    create_dir_all(&docs_dir)?;
+
+    let mut registry = endpoint_libs::model::TypeRegistry::new();
+    registry.add_all(crate::rust::shared_type_definitions(data).iter());
+    for service in &data.services {
+        for endpoint in &service.endpoints {
+            registry.add_endpoint(&endpoint.schema);
+        }
+    }
+
+    for service in &data.services {
+        let tools = service
+            .endpoints
+            .iter()
+            .map(|endpoint| {
+                let schema = &endpoint.schema;
+                let mut tool = json!({
+                    "name": schema.tool_name(),
+                    "code": schema.code,
+                    "description": schema.description,
+                    "frontendFacing": endpoint.frontend_facing,
+                    "inputSchema": schema.to_mcp_input_schema(&registry).with_context(|| {
+                        format!("endpoint {} ({})", schema.name, schema.code)
+                    })?,
+                });
+                if !schema.returns.is_empty() {
+                    tool["outputSchema"] = schema
+                        .to_mcp_output_schema(&registry)
+                        .with_context(|| format!("endpoint {} ({})", schema.name, schema.code))?;
+                }
+                if schema.stream_response.is_some() {
+                    tool["streaming"] = json!(true);
+                }
+                Ok(tool)
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+
+        let filename = docs_dir.join(format!("{}_mcp_tools.json", service.name));
+        let file = File::create(&filename)
+            .with_context(|| format!("Failed to create MCP tools file: {}", filename.display()))?;
+        serde_json::to_writer_pretty(file, &json!({ "tools": tools }))?;
+    }
+    Ok(())
+}
+
 pub fn gen_systemd_services(data: &Data, app_name: &str, user: &str) -> eyre::Result<()> {
     create_dir_all(data.project_root.join("etc").join("systemd"))?;
 
@@ -303,4 +354,52 @@ pub fn gen_error_message_md(root: &Path, codes: &[ErrorCodeSchema]) -> eyre::Res
         writeln!(&mut doc_file, "|{}|{}|{}|", item.code, item.name, item.description)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::definitions::{EndpointSchemaElement, RustGenConfig};
+    use endpoint_libs::model::Field;
+
+    #[test]
+    fn mcp_tools_json_is_written_per_service() {
+        let dir = std::env::temp_dir().join(format!("endpointgen-mcp-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let data = Data {
+            project_root: dir.clone(),
+            output_dir: dir.clone(),
+            services: vec![GenService::new(
+                "user".to_string(),
+                1,
+                vec![EndpointSchemaElement {
+                    frontend_facing: true,
+                    config: RustGenConfig::default(),
+                    schema: EndpointSchema::new(
+                        "UserGetProfile",
+                        10010,
+                        vec![Field::new("user_id", Type::Int64)],
+                        vec![Field::new("ok", Type::Boolean)],
+                    )
+                    .with_description("Fetches a user profile."),
+                }],
+            )],
+            enums: vec![],
+            structs: vec![],
+            error_codes: vec![],
+        };
+
+        gen_mcp_tools_json(&data).unwrap();
+
+        let out = std::fs::read_to_string(dir.join("docs").join("user_mcp_tools.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let tool = &parsed["tools"][0];
+        assert_eq!(tool["name"], json!("user_get_profile"));
+        assert_eq!(tool["code"], json!(10010));
+        assert_eq!(tool["inputSchema"]["required"], json!(["userId"]));
+        assert_eq!(tool["outputSchema"]["properties"]["ok"]["type"], json!("boolean"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/error_codes.rs
+++ b/src/error_codes.rs
@@ -39,10 +39,10 @@ pub fn build_error_code_catalog(custom_error_codes: Vec<ErrorCodeSchema>) -> eyr
 
 pub fn validate_reserved_enum_names(enums: &[EnumElement]) -> eyre::Result<()> {
     for enum_element in enums {
-        if let Type::Enum { name, .. } = &enum_element.inner {
-            if name.to_case(Case::Pascal) == "ErrorCode" {
-                bail!("Enum name 'ErrorCode' is reserved for generated endpoint error codes");
-            }
+        if let Type::Enum { name, .. } = &enum_element.inner
+            && name.to_case(Case::Pascal) == "ErrorCode"
+        {
+            bail!("Enum name 'ErrorCode' is reserved for generated endpoint error codes");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ fn main() -> Result<()> {
 
     docs::gen_services_docs(&docs_data)?;
     docs::gen_md_docs(&docs_data)?;
+    // Raw data (not docs_data): MCP schemas camelCase field names themselves,
+    // matching the wire format regardless of the snake_case_fields config.
+    docs::gen_mcp_tools_json(&data)?;
     rust::gen_model_rs(&data)?;
     docs::gen_error_message_md(&data.project_root, &data.error_codes)?;
     Ok(())

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -333,6 +333,7 @@ pub fn gen_model_rs(data: &Data) -> eyre::Result<()> {
     }
     check_endpoint_codes(data, &mut model_file)?;
     dump_endpoint_schema(data, &mut model_file)?;
+    dump_type_registry(data, &mut model_file)?;
 
     let enum_ = Type::enum_(
         "ErrorCode",
@@ -513,9 +514,126 @@ pub fn dump_endpoint_schema(data: &Data, mut writer: impl Write) -> eyre::Result
     Ok(())
 }
 
+/// Collects every shared type definition (structs, enums, the generated
+/// `ErrorCode` enum) that endpoint schemas may reference by name.
+pub fn shared_type_definitions(data: &Data) -> Vec<Type> {
+    let mut types: Vec<Type> = data.structs.iter().map(|s| s.inner.clone()).collect();
+    types.extend(data.enums.iter().map(|e| e.inner.clone()));
+    types.push(Type::enum_(
+        "ErrorCode",
+        data.error_codes
+            .iter()
+            .map(|x| EnumVariant::new_with_description(error_code_variant_name(&x.name), x.description.clone(), x.code))
+            .collect(),
+    ));
+    types
+}
+
+/// Emits `TYPE_DEFINITIONS` and `type_registry()` into the generated model:
+/// the full list of shared type definitions serialized as JSON (same embedding
+/// pattern as `WsRequest::SCHEMA`), plus a helper that deserializes them into
+/// an `endpoint_libs::model::TypeRegistry` for `WebsocketServer::enable_mcp()`.
+pub fn dump_type_registry(data: &Data, mut writer: impl Write) -> eyre::Result<()> {
+    let types = shared_type_definitions(data);
+    let serialized = serde_json::to_string_pretty(&types)?;
+    let code = format!(
+        r##"
+/// JSON-serialized shared struct/enum definitions referenced by endpoint schemas.
+pub const TYPE_DEFINITIONS: &'static str = r#"{serialized}"#;
+
+/// Builds the type registry over all shared definitions, for use with
+/// `WebsocketServer::enable_mcp()`.
+pub fn type_registry() -> endpoint_libs::model::TypeRegistry {{
+    let types: Vec<endpoint_libs::model::Type> =
+        serde_json::from_str(TYPE_DEFINITIONS).expect("Invalid embedded type definitions");
+    let mut registry = endpoint_libs::model::TypeRegistry::new();
+    registry.add_all(types.iter());
+    registry
+}}
+"##
+    );
+    writeln!(writer, "{code}")?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use regex::Regex;
+
+    use super::*;
+    use crate::definitions::{EndpointSchemaElement, RustGenConfig};
+    use endpoint_libs::model::{EndpointSchema, Field};
+
+    fn test_data() -> Data {
+        let user_info = Type::struct_(
+            "UserInfo",
+            vec![
+                Field::new("user_id", Type::Int64),
+                Field::new("role", Type::enum_ref("role", true)),
+            ],
+        );
+        let role = Type::enum_("role", vec![EnumVariant::new("Admin", 1)]);
+        Data {
+            project_root: std::path::PathBuf::new(),
+            output_dir: std::path::PathBuf::new(),
+            services: vec![crate::definitions::GenService::new(
+                "user".to_string(),
+                1,
+                vec![EndpointSchemaElement {
+                    frontend_facing: true,
+                    config: RustGenConfig::default(),
+                    schema: EndpointSchema::new(
+                        "UserGetProfile",
+                        10010,
+                        vec![Field::new("user_id", Type::Int64)],
+                        vec![Field::new("profile", Type::struct_ref("UserInfo"))],
+                    )
+                    .with_description("Fetches a user profile."),
+                }],
+            )],
+            enums: vec![crate::definitions::EnumElement {
+                config: RustGenConfig::default(),
+                inner: role,
+            }],
+            structs: vec![crate::definitions::StructElement {
+                config: RustGenConfig::default(),
+                inner: user_info,
+            }],
+            error_codes: vec![],
+        }
+    }
+
+    #[test]
+    fn type_registry_dump_round_trips() {
+        let data = test_data();
+        let mut out = Vec::new();
+        dump_type_registry(&data, &mut out).unwrap();
+        let code = String::from_utf8(out).unwrap();
+
+        assert!(code.contains("pub const TYPE_DEFINITIONS"));
+        assert!(code.contains("pub fn type_registry()"));
+
+        // Extract the embedded JSON and round-trip it the way the generated
+        // type_registry() will at runtime.
+        let start = code.find("r#\"").unwrap() + 3;
+        let end = code.find("\"#").unwrap();
+        let types: Vec<Type> = serde_json::from_str(&code[start..end]).unwrap();
+        // UserInfo struct + role enum + ErrorCode enum
+        assert_eq!(types.len(), 3);
+
+        let mut registry = endpoint_libs::model::TypeRegistry::new();
+        registry.add_all(types.iter());
+        assert!(registry.get_struct("UserInfo").is_some());
+        assert!(registry.get_enum("role").is_some());
+        assert!(registry.get_enum("ErrorCode").is_some());
+
+        // The registry must be able to resolve the endpoint's schemas.
+        let schema = &data.services[0].endpoints[0].schema;
+        let input = schema.to_mcp_input_schema(&registry).unwrap();
+        assert_eq!(input["required"], serde_json::json!(["userId"]));
+        let output = schema.to_mcp_output_schema(&registry).unwrap();
+        assert!(output["$defs"]["UserInfo"].is_object());
+    }
 
     #[test]
     fn test_extract_number_from_error_code() {


### PR DESCRIPTION
## Summary

Generator-side companion to the endpoint-libs MCP surface (pathscale/endpoint-libs#34, #35, #36).

- **rust.rs**: `gen_model_rs` now also emits `TYPE_DEFINITIONS` (all shared struct/enum definitions plus the generated `ErrorCode` enum, JSON-embedded with the same pattern as `WsRequest::SCHEMA`) and a `type_registry()` helper. Services enable MCP with one line:

  ```rust
  server.enable_mcp(&type_registry(), McpServerInfo { name, version })?;
  ```

- **docs.rs**: `gen_mcp_tools_json()` writes `docs/<service>_mcp_tools.json` — each endpoint's MCP tool entry (snake_case name, `inputSchema`, `outputSchema`, streaming flag) exactly as `tools/list` will report it, so schema changes surface as reviewable diffs
- **main.rs**: MCP docs generated from raw (non-camelCased) data — the JSON Schema conversion camelCases field names itself, matching the wire format

## ⚠️ Release coordination
`Cargo.toml` carries a **temporary `[patch.crates-io]`** pointing `endpoint-libs` at the sibling checkout, since the MCP APIs aren't published yet. Before merging/releasing: land the endpoint-libs PRs, publish, bump the `endpoint-libs` requirement here, and drop the patch. (Minor versions must stay in sync per the compatibility policy.)

## Test plan
- New tests: `type_registry_dump_round_trips` (embedded JSON round-trips into a working `TypeRegistry` that resolves endpoint schemas) and `mcp_tools_json_is_written_per_service`
- `cargo test` green (4 tests), `cargo build` clean against the patched endpoint-libs

🤖 Generated with [Claude Code](https://claude.com/claude-code)